### PR TITLE
Even more cleanup

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -20,11 +20,9 @@
       ],
       "cflags!": [
         "-fno-exceptions",
-        "-Wno-literal-suffix"
       ],
       "cflags_cc!": [
         "-fno-exceptions",
-        "-Wno-literal-suffix"
       ],
       "cflags": [
         "<!@(perl -MExtUtils::Embed -e ccopts)",
@@ -32,7 +30,6 @@
         "-Wno-cast-function-type"
       ],
       "ccflags": [
-        "-fno-exceptions",
         "-Wno-literal-suffix"
       ],
       "conditions": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -5835,16 +5835,6 @@
         "xmlchars": "^2.2.0"
       }
     },
-    "segfault-handler": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/segfault-handler/-/segfault-handler-1.3.0.tgz",
-      "integrity": "sha512-p7kVHo+4uoYkr0jmIiTBthwV5L2qmWtben/KDunDZ834mbos+tY+iO0//HpAJpOFSQZZ+wxKWuRo4DxV02B7Lg==",
-      "dev": true,
-      "requires": {
-        "bindings": "^1.2.1",
-        "nan": "^2.14.0"
-      }
-    },
     "semver": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "eslint-plugin-promise": "^4.2.1",
     "eslint-plugin-standard": "^4.0.1",
     "jest": "^26.0.1",
-    "segfault-handler": "^1.3.0",
     "tap": "^14.10.7"
   },
   "scripts": {

--- a/src/perl_bindings.cc
+++ b/src/perl_bindings.cc
@@ -250,7 +250,7 @@ class NodePerlMethod : public Nan::ObjectWrap, public PerlFoo
 
     std::string name_;
 
-    NodePerlMethod(SV *sv, const char *name, PerlInterpreter *myp): sv_(sv), name_(name), PerlFoo(myp)
+    NodePerlMethod(SV *sv, const char *name, PerlInterpreter *myp): PerlFoo(myp), sv_(sv), name_(name)
     {
         SvREFCNT_inc(sv);
     }
@@ -417,7 +417,7 @@ class NodePerlObject : public Nan::ObjectWrap, public PerlFoo
         return scope.Escape(retval);
     }
 
-    NodePerlObject(SV *sv, PerlInterpreter *myp): sv_(sv), PerlFoo(myp)
+    NodePerlObject(SV *sv, PerlInterpreter *myp): PerlFoo(myp), sv_(sv)
     {
         SvREFCNT_inc(sv);
     }
@@ -671,10 +671,7 @@ class NodePerl : public Nan::ObjectWrap, public PerlFoo
   private:
     void destroy()
     {
-        NodePerl *nodePerl = this;
-
         this->persistent().Reset();
-
         this->~NodePerl();
     }
 


### PR DESCRIPTION
Cleans up the compiler flags so we don't remove options then add them back, removed an unused dependency that was itself spewing compiler warnings on install, and fixes the remaining warnings in our code. The end result is a fully clean build, no warnings at all. This will make it obvious in the future when we do something that might be wrong or when something in NAN or V8 gets deprecated.